### PR TITLE
Fix Invalid spatial files

### DIFF
--- a/rezoning_api/utils.py
+++ b/rezoning_api/utils.py
@@ -27,7 +27,7 @@ s3 = boto3.client("s3")
 
 def s3_get(bucket: str, key: str, full_response=False):
     """Get AWS S3 Object."""
-        response = s3.get_object(Bucket=bucket, Key=key)
+    response = s3.get_object(Bucket=bucket, Key=key)
     if full_response:
         return response
     return response["Body"].read()

--- a/rezoning_api/utils.py
+++ b/rezoning_api/utils.py
@@ -27,7 +27,7 @@ s3 = boto3.client("s3")
 
 def s3_get(bucket: str, key: str, full_response=False):
     """Get AWS S3 Object."""
-    response = s3.get_object(Bucket=bucket, Key=key)
+        response = s3.get_object(Bucket=bucket, Key=key)
     if full_response:
         return response
     return response["Body"].read()
@@ -424,7 +424,7 @@ def calc_score(
                 if cmm:
                     layer_min = cmm[layer]["min"]
                     layer_max = cmm[layer]["max"]
-                else:
+                if not cmm or layer_min == layer_max:
                     key = loc.replace(f"s3://{BUCKET}/", "").replace("tif", "vrt")
                     layer_min_arr, layer_max_arr = get_min_max(s3_get(BUCKET, key))
                     layer_min = layer_min_arr[idx]


### PR DESCRIPTION
### Addresses https://github.com/kartoza/rezoning-2-project/issues/25:
- Previously calculating zones for Cape Verde resulted in a 500 internal error in the server and resulted in infinite values being exported, this fixes the problem.
- The exported Cape Verde .tif file in QGIS:
![Screenshot from 2022-12-19 11-00-44](https://user-images.githubusercontent.com/29183781/208399336-a12d9b7f-9f1a-4b88-831a-91873796c7b6.png)

